### PR TITLE
chocolate-doom: Fix copyright line

### DIFF
--- a/games-fps/chocolate-doom/chocolate_doom-3.0.1.recipe
+++ b/games-fps/chocolate-doom/chocolate_doom-3.0.1.recipe
@@ -3,10 +3,7 @@ DESCRIPTION="Chocolate Doom is a source port of the game Doom, by id Software. \
 The purpose of Chocolate Doom is to be as compatible as possible with the \
 original DOS version of Doom."
 HOMEPAGE="https://www.chocolate-doom.org/"
-COPYRIGHT="Id Software Inc. 1993-1996
-	Simon Howard
-	James Haley
-	Samuel Villarreal"
+COPYRIGHT="1993-2024 Id Software Inc., Simon Howard, James Haley, Samuel Villarreal et. al"
 LICENSE="GNU GPL v2"
 REVISION="3"
 SOURCE_URI="https://www.chocolate-doom.org/downloads/$portVersion/chocolate-doom-$portVersion.tar.gz"


### PR DESCRIPTION
Currently only the last name in the list is displayed:

<img width="759" alt="Screenshot 2024-08-06 at 10 40 06 AM" src="https://github.com/user-attachments/assets/14b7eec6-c7ef-4066-a050-c8ab717b9324">
